### PR TITLE
Add support for PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: php
 php:
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
 
 before_script:
   - composer install --dev
-  
+
 script:
   - vendor/bin/phpstan analyse
   - vendor/bin/phpunit --coverage-clover=coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^7.3",
+    "php": "^7.3 || ~8.0.0 || ~8.1.0",
     "ext-simplexml": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Hey,

the tests runs fine with PHP 8.0 and PHP 8.1
It would be awesome if you could add the new PHP Versions into the composer.json 