### PR TITLE
Rewrite to a generator based implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ vendor/
 .php_cs.cache
 phpunit.xml
 phpstan.neon
+.php-cs-fixer.cache
 .phpunit.result.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -8,4 +8,4 @@ $finder = PhpCsFixer\Finder::create()->in([
     __DIR__ . '/data',
 ]);
 
-return PhpCsFixer\Config::create()->setFinder($finder);
+return (new PhpCsFixer\Config())->setFinder($finder);

--- a/README.md
+++ b/README.md
@@ -18,8 +18,16 @@ Sentence boundary disambiguation (SBD) - or sentence breaking - library written 
     $breaker = new SentenceBreaker();
     $breaker->addAbbreviations(['Dr', 'Prof']);
     
+    // returns a generator, the text is parsed lazily
     $sentences = $breaker->split("Hello Dr. Jones! How are you? I'm fine, thanks!");
-    // ['Hello Dr. Jones!', 'How are you?', "I'm fine, thanks!"]
+
+    // get first
+    $sentences->current() // 'Hello Dr. Jones!'
+
+    // get all as array
+    iterator_to_array($sentences) // ['Hello Dr. Jones!', 'How are you?', "I'm fine, thanks!"]
+    
+
 
 ### Rules
 

--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
     }
   ],
   "require": {
-    "php": "^7.3 || ~8.0.0 || ~8.1.0",
+    "php": "^7.4 || ~8.0.0 || ~8.1.0",
     "ext-simplexml": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9",
     "fabpot/goutte": "^2",
-    "friendsofphp/php-cs-fixer": "^2.16",
-    "phpstan/phpstan": "^0.12.14",
-    "phpstan/phpstan-phpunit": "^0.12.6"
+    "friendsofphp/php-cs-fixer": "^3.4",
+    "phpstan/phpstan": "^1.0",
+    "phpstan/phpstan-phpunit": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/data/filter.php
+++ b/data/filter.php
@@ -1,29 +1,30 @@
 <?php
+
 declare(strict_types=1);
 
 foreach (glob(__DIR__ . '/*.txt') as $file) {
     $data = file_get_contents($file);
     $data = str_replace("\r", '', $data);
-    
+
     $lines = explode("\n", $data);
-    
+
     $lines = array_map(static function ($line) {
         [$line] = explode('--', $line);
-        
+
         return trim($line);
     }, $lines);
-    
+
     $lines = array_filter($lines, static function ($line) {
         return '.' === substr($line, -1);
     });
-    
+
     $lines = array_unique($lines);
     asort($lines);
-    
+
     $data = join("\n", $lines);
-    
+
     file_put_contents($file, $data);
-    
+
     echo $file . " ... DONE\n";
 }
 

--- a/data/pack.php
+++ b/data/pack.php
@@ -9,7 +9,7 @@ foreach (glob(__DIR__ . '/*.txt') as $file) {
     $data = file_get_contents($file);
     $lines = array_merge($lines, explode("\n", $data));
 }
-    
+
 $lines = array_unique($lines);
 asort($lines);
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,5 @@
 parameters:
+    phpVersion: 70400 # PHP 7.4
     level: 9
     paths:
         - src

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 9
     paths:
         - src
         - tests/src

--- a/src/Abbreviations/Abbreviations.php
+++ b/src/Abbreviations/Abbreviations.php
@@ -7,7 +7,7 @@ namespace Bigwhoop\SentenceBreaker\Abbreviations;
 class Abbreviations
 {
     /** @var string[] */
-    private $abbreviations = [];
+    private array $abbreviations = [];
 
     /**
      * @param string[] $abbreviations

--- a/src/Abbreviations/ArrayProvider.php
+++ b/src/Abbreviations/ArrayProvider.php
@@ -6,13 +6,19 @@ namespace Bigwhoop\SentenceBreaker\Abbreviations;
 
 class ArrayProvider implements ValueProvider
 {
-    private $values = [];
+    /**
+     * @var array<string>
+     */
+    private $values;
 
+    /**
+     * @param array<string> $values
+     */
     public function __construct(array $values)
     {
         $this->values = $values;
     }
-    
+
     public function getValues(): array
     {
         return $this->values;

--- a/src/GeneratorOffsetIterator.php
+++ b/src/GeneratorOffsetIterator.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigwhoop\SentenceBreaker;
+
+use Generator;
+use Iterator;
+
+/**
+ * @template T
+ * @implements Iterator<T>
+ */
+class GeneratorOffsetIterator implements Iterator
+{
+    /**
+     * @var Generator<int, T, mixed, void>
+     */
+    private Generator $generator;
+
+    /** @var array<T> */
+    private array $cache = [];
+
+    private int $currentIndex = 0;
+
+    /**
+     * @param Generator<int, T, mixed, void> $generator
+     */
+    public function __construct(iterable $generator)
+    {
+        $this->generator = $generator;
+        $this->addCurrentToCache();
+    }
+
+    public function current()
+    {
+        return $this->cache[$this->currentIndex];
+    }
+
+    public function next(): void
+    {
+        if ($this->currentIndex === $this->generator->key()) {
+            $this->generator->next();
+            $this->addCurrentToCache();
+        }
+
+        $this->currentIndex++;
+    }
+
+    public function key(): int
+    {
+        return $this->currentIndex;
+    }
+
+    public function valid(): bool
+    {
+        return array_key_exists($this->currentIndex, $this->cache);
+    }
+
+    public function rewind(): void
+    {
+        $this->currentIndex = 0;
+    }
+
+    private function addCurrentToCache(): void
+    {
+        if ($this->generator->valid()) {
+            $this->cache[] = $this->generator->current();
+        }
+    }
+
+    /**
+     * @return false|T
+     */
+    public function getByOffset(int $offset)
+    {
+        if ($offset === 0) {
+            return $this->current();
+        }
+
+        if ($offset < 0) {
+            return $this->cache[$this->currentIndex - abs($offset)] ?? false;
+        }
+
+        $currentIndex = $this->currentIndex;
+
+        // look ahead
+        foreach (range(1, $offset) as $ignored) {
+            if (!$this->valid()) {
+                break;
+            }
+            $this->next();
+        }
+
+        if ($this->valid()) {
+            $current = $this->current();
+        } else {
+            $current = false;
+        }
+
+        // reset current index
+        $this->currentIndex = $currentIndex;
+
+        return $current;
+    }
+}

--- a/src/Lexing/States/ParenthesesState.php
+++ b/src/Lexing/States/ParenthesesState.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\States;
@@ -11,7 +12,10 @@ class ParenthesesState extends State
     private const CHARS = [
         '(' => ')',
     ];
-    
+
+    /**
+     * @return array<string>
+     */
     public static function getOpeningParentheses(): array
     {
         return array_keys(self::CHARS);

--- a/src/Lexing/States/QuotedStringState.php
+++ b/src/Lexing/States/QuotedStringState.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\States;
@@ -15,7 +16,10 @@ class QuotedStringState extends State
         '“' => '”',
         '„' => '”',
     ];
-    
+
+    /**
+     * @return array<string>
+     */
     public static function getLeftMarks(): array
     {
         return array_keys(self::MARKS);

--- a/src/Lexing/States/State.php
+++ b/src/Lexing/States/State.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\States;

--- a/src/Lexing/States/StateException.php
+++ b/src/Lexing/States/StateException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\States;

--- a/src/Lexing/States/TextState.php
+++ b/src/Lexing/States/TextState.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\States;
@@ -8,7 +9,6 @@ use Bigwhoop\SentenceBreaker\Lexing\Tokens\EOFToken;
 use Bigwhoop\SentenceBreaker\Lexing\Tokens\ExclamationPointToken;
 use Bigwhoop\SentenceBreaker\Lexing\Tokens\PeriodToken;
 use Bigwhoop\SentenceBreaker\Lexing\Tokens\QuestionMarkToken;
-use Bigwhoop\SentenceBreaker\Lexing\Tokens\StringInParenthesesToken;
 
 class TextState extends State
 {
@@ -19,7 +19,7 @@ class TextState extends State
     {
         while (true) {
             $peek = $lexer->peek();
-            
+
             if ($peek === null) {
                 $lexer->emit(new EOFToken());
 

--- a/src/Lexing/States/WhitespaceState.php
+++ b/src/Lexing/States/WhitespaceState.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\States;

--- a/src/Lexing/States/WordState.php
+++ b/src/Lexing/States/WordState.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\States;
@@ -9,6 +10,9 @@ use Bigwhoop\SentenceBreaker\Lexing\Tokens\WordToken;
 
 class WordState extends State
 {
+    /**
+     * @return array<string|null>
+     */
     private function getNonWordChars(): array
     {
         return array_merge(['.', '?', '!', null], WhitespaceState::CHARS);

--- a/src/Lexing/Tokens/AbbreviationToken.php
+++ b/src/Lexing/Tokens/AbbreviationToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Lexing/Tokens/CapitalizedWordToken.php
+++ b/src/Lexing/Tokens/CapitalizedWordToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Lexing/Tokens/EOFToken.php
+++ b/src/Lexing/Tokens/EOFToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;
@@ -9,7 +10,7 @@ class EOFToken implements Token
     {
         return 'T_EOF';
     }
-    
+
     public function getPrintableValue(): string
     {
         return '';

--- a/src/Lexing/Tokens/ExclamationPointToken.php
+++ b/src/Lexing/Tokens/ExclamationPointToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;
@@ -9,7 +10,7 @@ class ExclamationPointToken implements Token
     {
         return 'T_EXCLAMATION_POINT';
     }
-    
+
     public function getPrintableValue(): string
     {
         return '!';

--- a/src/Lexing/Tokens/PeriodToken.php
+++ b/src/Lexing/Tokens/PeriodToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Lexing/Tokens/PotentialAbbreviationToken.php
+++ b/src/Lexing/Tokens/PotentialAbbreviationToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Lexing/Tokens/QuestionMarkToken.php
+++ b/src/Lexing/Tokens/QuestionMarkToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Lexing/Tokens/QuotedStringToken.php
+++ b/src/Lexing/Tokens/QuotedStringToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Lexing/Tokens/StringInParenthesesToken.php
+++ b/src/Lexing/Tokens/StringInParenthesesToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Lexing/Tokens/Token.php
+++ b/src/Lexing/Tokens/Token.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Lexing/Tokens/ValueToken.php
+++ b/src/Lexing/Tokens/ValueToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;
@@ -6,7 +7,7 @@ namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;
 abstract class ValueToken implements Token
 {
     /** @var string */
-    private $value;
+    private string $value;
 
     public function __construct(string $value = '')
     {

--- a/src/Lexing/Tokens/WhitespaceToken.php
+++ b/src/Lexing/Tokens/WhitespaceToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Lexing/Tokens/WordToken.php
+++ b/src/Lexing/Tokens/WordToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Lexing\Tokens;

--- a/src/Rules/Configuration.php
+++ b/src/Rules/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Rules;

--- a/src/Rules/ConfigurationException.php
+++ b/src/Rules/ConfigurationException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Rules;

--- a/src/Rules/IniConfiguration.php
+++ b/src/Rules/IniConfiguration.php
@@ -1,14 +1,17 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Rules;
 
 class IniConfiguration implements Configuration
 {
-    private $data = [];
+    /**
+     * @var array<mixed>
+     */
+    private array $data = [];
 
     /**
-     * @param string $path
      * @return self
      * @throws ConfigurationException
      */
@@ -18,12 +21,16 @@ class IniConfiguration implements Configuration
             throw new ConfigurationException("File '{$path}' must be readable.");
         }
 
-        return new self(file_get_contents($path));
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new ConfigurationException("Unable to read '{$path}'.");
+        }
+
+        return new self($contents);
     }
 
     /**
-     * @param string $data
-     * @throws ConfigurationException
+      @throws ConfigurationException
      */
     public function __construct(string $data)
     {
@@ -31,7 +38,7 @@ class IniConfiguration implements Configuration
         if ($parsedData === false) {
             throw new ConfigurationException('Failed parsing given INI string');
         }
-        
+
         $this->data = $parsedData;
     }
 

--- a/src/Rules/Rule.php
+++ b/src/Rules/Rule.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Rules;
@@ -6,10 +7,10 @@ namespace Bigwhoop\SentenceBreaker\Rules;
 class Rule
 {
     /** @var string */
-    private $tokenName;
+    private string $tokenName;
 
     /** @var RulePattern[] */
-    private $patterns = [];
+    private array $patterns = [];
 
     /**
      * @param string        $tokenName

--- a/src/Rules/RulePattern.php
+++ b/src/Rules/RulePattern.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Rules;
@@ -6,21 +7,21 @@ namespace Bigwhoop\SentenceBreaker\Rules;
 class RulePattern
 {
     /** @var int */
-    private $probability;
+    private int $probability;
 
-    /** @var RulePatternToken[] */
-    private $tokens = [];
+    /** @var array<int, RulePatternToken> */
+    private array $tokens = [];
 
     /**
      * @param int                $probability
-     * @param RulePatternToken[] $tokens
+     * @param array<int, RulePatternToken> $tokens
      */
     public function __construct(int $probability, array $tokens = [])
     {
         $this->probability = $probability;
         $this->addTokens($tokens);
     }
-    
+
     public function getProbability(): int
     {
         return $this->probability;
@@ -48,13 +49,11 @@ class RulePattern
      * If the $startTokenName were T_A we'd return: 0, 1, 2, 3
      * If the $startTokenName were T_C we'd return: -2, -1, 0, 1
      *
-     * @param string $startTokenName
-     *
      * @return RulePatternToken[]
      *
      * @throws ConfigurationException
      */
-    public function getTokensOffsetRelativeToStartToken($startTokenName): array
+    public function getTokensOffsetRelativeToStartToken(string $startTokenName): array
     {
         $startTokenIdx = null;
 
@@ -70,12 +69,12 @@ class RulePattern
             throw new ConfigurationException('No start token found for pattern '.print_r($this, true));
         }
 
-        $numTokens = count($this->tokens);
+        $offsets = array_map(
+            static fn (int $idx) => $idx - $startTokenIdx,
+            range(0, count($this->tokens) -1)
+        );
 
-        $offsets = array_map(static function ($idx) use ($startTokenIdx) {
-            return $idx - $startTokenIdx;
-        }, range(0, $numTokens - 1));
-
+        /** @phpstan-ignore-next-line */
         return array_combine($offsets, $this->tokens);
     }
 }

--- a/src/Rules/RulePatternToken.php
+++ b/src/Rules/RulePatternToken.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Rules;
@@ -6,10 +7,10 @@ namespace Bigwhoop\SentenceBreaker\Rules;
 class RulePatternToken
 {
     /** @var string */
-    private $tokenName;
+    private string $tokenName;
 
     /** @var bool */
-    private $isStartToken;
+    private bool $isStartToken;
 
     /**
      * @param string $tokenName

--- a/src/Rules/Rules.php
+++ b/src/Rules/Rules.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Rules;
@@ -6,7 +7,7 @@ namespace Bigwhoop\SentenceBreaker\Rules;
 class Rules
 {
     /** @var Rule[] */
-    private $rules = [];
+    private array $rules = [];
 
     /**
      * @param Rule[] $rules

--- a/src/SentenceBreaker.php
+++ b/src/SentenceBreaker.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker;
@@ -12,20 +13,21 @@ use Bigwhoop\SentenceBreaker\Abbreviations\ArrayProvider;
 use Bigwhoop\SentenceBreaker\Abbreviations\ValueProvider;
 use Bigwhoop\SentenceBreaker\Lexing\Lexer;
 use Bigwhoop\SentenceBreaker\Rules\Rules;
+use Generator;
 
 class SentenceBreaker
 {
     /** @var ValueProvider[] */
-    private $abbreviationProviders = [];
+    private array $abbreviationProviders = [];
 
     /** @var Lexer */
-    private $lexer;
+    private Lexer $lexer;
 
     /** @var ProbabilityCalculator */
-    private $probabilityCalculator;
+    private ProbabilityCalculator $probabilityCalculator;
 
     /** @var SentenceBuilder */
-    private $sentenceBuilder;
+    private SentenceBuilder $sentenceBuilder;
 
     /**
      * @param Configuration|null $rulesConfig
@@ -41,7 +43,6 @@ class SentenceBreaker
     }
 
     /**
-     * @return Rules
      * @throws ConfigurationException
      */
     private function loadDefaultRules(): Rules
@@ -75,7 +76,7 @@ class SentenceBreaker
     }
 
     /**
-     * @param array|ValueProvider $values
+     * @param array<string>|ValueProvider $values
      *
      * @throws InvalidArgumentException
      */
@@ -91,18 +92,18 @@ class SentenceBreaker
     }
 
     /**
-     * @param string $text
-     * @return string[]
+     * @return Generator<string>
      * @throws ConfigurationException
      * @throws Lexing\States\StateException
      */
-    public function split(string $text): array
+    public function split(string $text): Generator
     {
         $this->probabilityCalculator->setAbbreviations($this->getAbbreviations());
 
         $tokens = $this->lexer->run($text);
+
         $probabilities = $this->probabilityCalculator->calculate($tokens);
-        
+
         return $this->sentenceBuilder->build($probabilities);
     }
 

--- a/src/SentenceBuilder.php
+++ b/src/SentenceBuilder.php
@@ -1,40 +1,32 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker;
 
+use Generator;
+
 class SentenceBuilder
 {
     /**
-     * @param TokenProbability[] $tokenProbabilities
-     * @param int                $threshold
+     * @param iterable<TokenProbability> $tokenProbabilities
      *
-     * @return array
+     * @return Generator<string>
      */
-    public function build(array $tokenProbabilities, int $threshold = 50): array
+    public function build(iterable $tokenProbabilities, int $threshold = 50): Generator
     {
-        $sentences = [''];
+        $currentSentence = '';
 
-        foreach ($tokenProbabilities as $idx => $tokenProbability) {
+        foreach ($tokenProbabilities as $tokenProbability) {
             $token = $tokenProbability->getToken();
-
-            $sentenceIdx = count($sentences) - 1;
-            $sentences[$sentenceIdx] .= $token->getPrintableValue();
-
+            $currentSentence .= $token->getPrintableValue();
             $meetsThreshold = $tokenProbability->getProbability() >= $threshold;
-            $currentSentenceIsEmpty = empty(trim($sentences[$sentenceIdx]));
+            $currentSentenceIsEmpty = empty(trim($currentSentence));
 
             if ($meetsThreshold && !$currentSentenceIsEmpty) {
-                $sentences[] = '';
+                yield ltrim($currentSentence);
+                $currentSentence = '';
             }
         }
-
-        if ('' === $sentences[count($sentences) - 1]) {
-            unset($sentences[count($sentences) - 1]);
-        }
-
-        $sentences = array_map('ltrim', $sentences);
-
-        return $sentences;
     }
 }

--- a/src/TokenProbability.php
+++ b/src/TokenProbability.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker;
@@ -7,24 +8,16 @@ use Bigwhoop\SentenceBreaker\Lexing\Tokens\Token;
 
 class TokenProbability
 {
-    /** @var Token|string */
-    private $token;
+    private Token $token;
 
-    /** @var int */
-    private $probability = 0;
+    private int $probability = 0;
 
-    /**
-     * @param Token|string $token
-     */
-    public function __construct($token)
+    public function __construct(Token $token)
     {
         $this->token = $token;
     }
 
-    /**
-     * @return Token|string
-     */
-    public function getToken()
+    public function getToken(): Token
     {
         return $this->token;
     }

--- a/tests/src/Abbreviations/FlatFileProviderTest.php
+++ b/tests/src/Abbreviations/FlatFileProviderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Tests\Abbreviations;

--- a/tests/src/GeneratorOffsetIteratorTest.php
+++ b/tests/src/GeneratorOffsetIteratorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigwhoop\SentenceBreaker\Tests;
+
+use Bigwhoop\SentenceBreaker\GeneratorOffsetIterator;
+use PHPUnit\Framework\TestCase;
+
+class GeneratorOffsetIteratorTest extends TestCase
+{
+    public function testCanAccessPreviousAndNextValuesByOffset(): void
+    {
+        $generatorInvocationCount = 0;
+        $yieldSequence = function () use (&$generatorInvocationCount) {
+            $generatorInvocationCount++;
+            yield from range(100, 110);
+        };
+
+        $iterator = new GeneratorOffsetIterator($yieldSequence());
+
+        $value = null;
+        foreach ($iterator as $index => $value) {
+            if ($index === 5) {
+                self::assertSame(105, $value);
+                self::assertSame(105, $iterator->getByOffset(0));
+                self::assertSame(103, $iterator->getByOffset(-2));
+                self::assertSame(107, $iterator->getByOffset(2));
+                self::assertFalse($iterator->getByOffset(-99));
+                self::assertSame(110, $iterator->getByOffset(5));
+                self::assertFalse($iterator->getByOffset(1123));
+            }
+        }
+
+        self::assertSame(110, $value);
+        self::assertSame(1, $generatorInvocationCount);
+    }
+}

--- a/tests/src/Lexing/LexerTest.php
+++ b/tests/src/Lexing/LexerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Tests\Lexing;
@@ -134,7 +135,7 @@ class LexerTest extends TestCase
      *
      * @return string[]
      */
-    private function getTokenStrings(array $tokens): array
+    private function getTokenStrings(iterable $tokens): array
     {
         $values = [];
 

--- a/tests/src/ProbabilityCalculatorTest.php
+++ b/tests/src/ProbabilityCalculatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Tests;
@@ -15,6 +16,9 @@ use PHPUnit\Framework\TestCase;
 
 class ProbabilityCalculatorTest extends TestCase
 {
+    /**
+     * @return array<mixed>
+     */
     public function dataSimpleSentences(): array
     {
         return [
@@ -32,6 +36,9 @@ class ProbabilityCalculatorTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<mixed>
+     */
     public function dataQuotes(): array
     {
         return [
@@ -54,6 +61,9 @@ class ProbabilityCalculatorTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<mixed>
+     */
     public function dataAbbreviations(): array
     {
         return [
@@ -79,7 +89,7 @@ class ProbabilityCalculatorTest extends TestCase
      * @dataProvider dataSimpleSentences
      *
      * @param string $input
-     * @param array  $expectedResult
+     * @param array<string>  $expectedResult
      */
     public function testSimpleSentences(string $input, array $expectedResult): void
     {
@@ -90,7 +100,7 @@ class ProbabilityCalculatorTest extends TestCase
      * @dataProvider dataQuotes
      *
      * @param string $input
-     * @param array  $expectedResult
+     * @param array<string>  $expectedResult
      */
     public function testQuotes(string $input, array $expectedResult): void
     {
@@ -101,8 +111,8 @@ class ProbabilityCalculatorTest extends TestCase
      * @dataProvider dataAbbreviations
      *
      * @param string $input
-     * @param array  $expectedResult
-     * @param array  $abbreviations
+     * @param array<string>  $expectedResult
+     * @param array<string>  $abbreviations
      */
     public function testAbbreviations(string $input, array $expectedResult, array $abbreviations): void
     {
@@ -111,8 +121,8 @@ class ProbabilityCalculatorTest extends TestCase
 
     /**
      * @param string $input
-     * @param array  $expectedResult
-     * @param array  $abbreviations
+     * @param array<string>  $expectedResult
+     * @param array<string>  $abbreviations
      */
     private function runCalculateTest(string $input, array $expectedResult, array $abbreviations): void
     {

--- a/tests/src/Rules/IniConfigurationTest.php
+++ b/tests/src/Rules/IniConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Tests\Rules;
@@ -43,7 +44,7 @@ class IniConfigurationTest extends TestCase
     {
         $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('.INI Configuration must contain \'rules\' section.');
-        
+
         $ini = <<<INI
 T_WORD <T_EOF> = 100
 INI;
@@ -51,12 +52,12 @@ INI;
         $config = new IniConfiguration($ini);
         $config->getRules();
     }
-    
+
     public function testMissingStartToken(): void
     {
         $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Pattern T_WORD T_EOF: Must contain start token.');
-        
+
         $ini = <<<INI
 [rules]
 T_WORD T_EOF = 100
@@ -70,7 +71,7 @@ INI;
     {
         $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Pattern T_WORD AA <T_EOF>: Token AA must exceed 2 characters.');
-        
+
         $ini = <<<INI
 [rules]
 T_WORD AA <T_EOF> = 100

--- a/tests/src/Rules/XMLConfigurationTest.php
+++ b/tests/src/Rules/XMLConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Tests\Rules;
@@ -42,7 +43,7 @@ class XMLConfigurationTest extends TestCase
     {
         $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Pattern T_EOF/#0 must have unambiguous start token. No T_EOF token found.');
-    
+
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
@@ -65,7 +66,7 @@ XML;
     {
         $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Pattern T_EOF/#0 must have unambiguous start token. Multiple T_EOF tokens found.');
-    
+
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
@@ -89,7 +90,7 @@ XML;
     {
         $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Pattern T_EOF#0: Multiple T_EOF tokens with \'is_start_token\' attribute found. Only one is allowed.');
-    
+
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
@@ -113,7 +114,7 @@ XML;
     {
         $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Pattern T_EOF#0: Only T_EOF tokens can have the \'is_start_token\' attribute.');
-    
+
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>

--- a/tests/src/SentenceBreakerPerformanceTest.php
+++ b/tests/src/SentenceBreakerPerformanceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigwhoop\SentenceBreaker\Tests;
+
+use Bigwhoop\SentenceBreaker\SentenceBreaker;
+use PHPUnit\Framework\TestCase;
+
+class SentenceBreakerPerformanceTest extends TestCase
+{
+    private const MAX_SENTENCES = 1000;
+
+    private const SENTENCES = [
+        'Doctor, as a title, originates from the Latin word of the same spelling and meaning.',
+        "The word is originally an agentive noun of the Latin verb docēre [dɔˈkeːrɛ] 'to teach'.",
+        'It has been used as an honored academic title for over a millennium in Europe, where it dates back to the rise of the first universities.',
+        'This use spread to the Americas, former European colonies, and is now prevalent in most of the world.',
+        'Contracted "Dr" or "Dr.", it is used as a designation for a person who has obtained a doctorate-level degree.',
+        'Doctorates may be research doctorates or professional doctorates.',
+    ];
+
+    public function testCanAccessTheFirstSentenceOfLargeText(): void
+    {
+        $exampleSentences = $this->generateSentencesInRandomOrder(self::MAX_SENTENCES);
+        $firstSentence    = $exampleSentences[0];
+        $text             = implode(' ', $exampleSentences);
+        unset($exampleSentences);
+
+        $breaker = new SentenceBreaker();
+        $breaker->addAbbreviations(['Dr', 'Prof']);
+
+        $sentences = $breaker->split($text);
+
+        foreach ($sentences as $sentence) {
+            // stop at first iteration so this test can be used
+            // with the old version that returned an array and
+            // the new version that returns a generator
+            self::assertSame($firstSentence, $sentence);
+            break;
+        }
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function generateSentencesInRandomOrder(int $max): array
+    {
+        $sentenceCount = count(self::SENTENCES);
+        $exampleSentences = [];
+        foreach (range(1, $max) as $ignored) {
+            $exampleSentences[] = self::SENTENCES[random_int(0, $sentenceCount - 1)];
+        }
+
+        return $exampleSentences;
+    }
+}

--- a/tests/src/SentenceBreakerTest.php
+++ b/tests/src/SentenceBreakerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Bigwhoop\SentenceBreaker\Tests;
@@ -15,30 +16,32 @@ class SentenceBreakerTest extends TestCase
         $breaker->addAbbreviations(['Dr', 'Prof']);
 
         $sentences = $breaker->split("Hello Dr. Jones! How are you? I'm fine, thanks!");
-        $this->assertSame(['Hello Dr. Jones!', 'How are you?', "I'm fine, thanks!"], $sentences);
+
+        $this->assertSame(['Hello Dr. Jones!', 'How are you?', "I'm fine, thanks!"], iterator_to_array($sentences));
     }
-    
+
     public function testPluralizedAbbreviation(): void
     {
         $breaker = new SentenceBreaker();
 
         $sentences = $breaker->split("So it looks like they've got F.D.R.'s for One Marine right now.");
-        $this->assertSame(["So it looks like they've got F.D.R.'s for One Marine right now."], $sentences);
+        $this->assertSame(["So it looks like they've got F.D.R.'s for One Marine right now."], iterator_to_array($sentences));
     }
 
     /**
      * @dataProvider dataSentences
+     * @param array<string> $sentences
      */
     public function testSplittingWithFlatFileProvider(string $text, array $sentences): void
     {
         $breaker = new SentenceBreaker();
         $breaker->addAbbreviations(new FlatFileProvider(__DIR__.'/../assets/data', ['*']));
 
-        $this->assertSame($sentences, $breaker->split($text));
+        $this->assertSame($sentences, iterator_to_array($breaker->split($text)));
     }
 
     /**
-     * @return array
+     * @return array<mixed>
      */
     public function dataSentences(): array
     {


### PR DESCRIPTION
Rewrite `Lexer`, `ProbabilityCalculator` and `SentenceBreaker` to use a
generator based implementation.

This allows to fetch the first sentence without having to lex and parse the whole text.

Even when fetching all sentences this will reduce overall memory usage because some intermediate steps in the `Lexer` and `ProbabilityCalculator` are more memory efficient now.

This contains breaking changes in the public methods of  `Lexer`, `ProbabilityCalculator` and `SentenceBreaker`.
I've also raised the minimum PHP Version to 7.4 and increased the phpstan level to 9.

Test `tests/src/SentenceBreakerPerformanceTest.php`

```php
public function testCanAccessTheFirstSentenceOfLargeText(): void
{
    $exampleSentences = $this->generateSentencesInRandomOrder(1000);
    $firstSentence    = $exampleSentences[0];
    $text             = implode(' ', $exampleSentences);
    unset($exampleSentences);

    $breaker = new SentenceBreaker();
    $breaker->addAbbreviations(['Dr', 'Prof']);

    $sentences = $breaker->split($text);

    foreach ($sentences as $sentence) {
        // stop at first iteration so this test can be used
        // with the old version that returned an array and
        // the new version that returns a generator
        self::assertSame($firstSentence, $sentence);
        break;
    }
}
```

`master`:

```
$ time ./vendor/bin/phpunit tests/src/SentenceBreakerPerformanceTest.php
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:39.509, Memory: 16.01 MB

OK (1 test, 1 assertion)

real	0m39.568s
user	0m38.362s
sys	0m0.688s
```


`lazy-generator-implementation`:

```
$ time ./vendor/bin/phpunit tests/src/SentenceBreakerPerformanceTest.php
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:00.004, Memory: 6.00 MB

OK (1 test, 1 assertion)

real	0m0.054s
user	0m0.026s
sys	0m0.018s
```