### PR TITLE
Improve performance on main Lexer class

### DIFF
--- a/src/Lexing/Lexer.php
+++ b/src/Lexing/Lexer.php
@@ -9,7 +9,8 @@ use Bigwhoop\SentenceBreaker\Lexing\Tokens\ValueToken;
 
 class Lexer
 {
-    private string $input;
+    /** @var string[] */
+    private array $inputChars = [];
 
     private ?States\State $state;
 
@@ -49,7 +50,7 @@ class Lexer
     private function setInput(string $input): void
     {
         $this->reset();
-        $this->input = $input;
+        $this->inputChars = mb_str_split($input);
     }
 
     private function reset(): void
@@ -67,10 +68,12 @@ class Lexer
 
     public function next(int $offset = 0): ?string
     {
-        $c = mb_substr($this->input, $this->pos + $offset, 1);
-        $this->pos += 1 + $offset;
+        $this->pos += $offset;
+        if (!isset($this->inputChars[$this->pos])) {
+            return null;
+        }
 
-        return $c === '' ? null : $c;
+        return $this->inputChars[$this->pos++];
     }
 
     public function last(): ?string
@@ -79,20 +82,12 @@ class Lexer
             return null;
         }
 
-        $c = mb_substr($this->input, $this->pos - 1, 1);
-
-        if ($c === '') {
-            return null;
-        }
-
-        return $c;
+        return $this->inputChars[$this->pos - 1] ?? null;
     }
 
     public function peek(int $offset = 0): ?string
     {
-        $c = mb_substr($this->input, $this->pos + $offset, 1);
-
-        return $c === '' ? null : $c;
+        return $this->inputChars[$this->pos + $offset] ?? null;
     }
 
     public function backup(int $offset = 0): void
@@ -110,12 +105,7 @@ class Lexer
         $startPos = $this->tokenPos;
         $endPos = $this->pos;
 
-        $value = '';
-        if ($endPos > $startPos) {
-            $value = mb_substr($this->input, $startPos, $endPos - $startPos);
-        }
-
-        return $value;
+        return implode('', array_slice($this->inputChars, $startPos, $endPos - $startPos));
     }
 
     public function emit(Token $token): void

--- a/src/Lexing/Lexer.php
+++ b/src/Lexing/Lexer.php
@@ -59,6 +59,7 @@ class Lexer
         $this->tokenPos = 0;
         $this->tokens = [];
         $this->state = new States\TextState();
+        $this->inputChars = [];
     }
 
     public function pos(): int
@@ -68,12 +69,10 @@ class Lexer
 
     public function next(int $offset = 0): ?string
     {
-        $this->pos += $offset;
-        if (!isset($this->inputChars[$this->pos])) {
-            return null;
-        }
+        $next = $this->inputChars[$this->pos + $offset] ?? null;
+        $this->pos += $offset + 1;
 
-        return $this->inputChars[$this->pos++];
+        return $next;
     }
 
     public function last(): ?string
@@ -104,6 +103,10 @@ class Lexer
     {
         $startPos = $this->tokenPos;
         $endPos = $this->pos;
+
+        if ($endPos <= $startPos) {
+            return '';
+        }
 
         return implode('', array_slice($this->inputChars, $startPos, $endPos - $startPos));
     }

--- a/src/Lexing/Lexer.php
+++ b/src/Lexing/Lexer.php
@@ -70,11 +70,7 @@ class Lexer
         $c = mb_substr($this->input, $this->pos + $offset, 1);
         $this->pos += 1 + $offset;
 
-        if ($c === '') {
-            return null;
-        }
-
-        return $c;
+        return $c === '' ? null : $c;
     }
 
     public function last(): ?string
@@ -94,10 +90,9 @@ class Lexer
 
     public function peek(int $offset = 0): ?string
     {
-        $c = $this->next($offset);
-        $this->backup($offset);
+        $c = mb_substr($this->input, $this->pos + $offset, 1);
 
-        return $c;
+        return $c === '' ? null : $c;
     }
 
     public function backup(int $offset = 0): void


### PR DESCRIPTION
Hi,

This improves the performance of the Lexer class's peek() method by not jumping positions using next() as well as using mb_str_split to only split the string once and not do it on every iteration

Measured performance increase was about 500% when working with huge payloads. For smaller texts there isn't a noticeable difference.

Please let me know if there is anything else that I can do, to move this forward!

Best Regards,
Ilian Kyuchukov